### PR TITLE
Add the 'chroma' to the chromatic scale. 🌈

### DIFF
--- a/examples/midi_keypad/midi_keypad.ino
+++ b/examples/midi_keypad/midi_keypad.ino
@@ -54,7 +54,7 @@ void loop() {
 
     if (e.bit.EVENT == KEY_JUST_PRESSED) {
       Serial.println(" pressed\n");
-      trellis.setPixelColor(key, 0xFFFFFF);
+      trellis.setPixelColor(key, Wheel((FIRST_MIDI_NOTE+key % 12)*(255/12)) );
       trellis.noteOn(FIRST_MIDI_NOTE+key, 64);
     }
     else if (e.bit.EVENT == KEY_JUST_RELEASED) {


### PR DESCRIPTION
Since the Wheel function is already in this example, it's kinda nice to get some visual feedback of which note is being pressed too!

(mod 12 because that's how many notes are in the chromatic scale, then multiply by 255/12 to evenly space them on Wheel's input)