### PR TITLE
Sanity check recorded sample length.

### DIFF
--- a/examples/sixteen_step_sequencer/sampler.cpp
+++ b/examples/sixteen_step_sequencer/sampler.cpp
@@ -134,6 +134,11 @@ void AudioPlayQspiRaw::play(uint32_t addr)
 {
 	// get length from file
 	flash.readBuffer(addr, (byte*)&length, sizeof(uint32_t));
+	// sanity check length
+	if (length > REC_FILESIZE) {
+		Serial.print("Length "); Serial.println(length); Serial.print(" exceeds file size "); Serial.println(REC_FILESIZE);
+		return;
+	}
 	playing = true;
 	_addr = addr + SFLASH_SECTOR_SIZE;
 	Serial.println(length);


### PR DESCRIPTION
Simple fix for behavior discovered here:
https://forums.adafruit.com/viewtopic.php?f=19&t=155625

If QSPI has been used for something else, like a CircuitPython filesystem, an immediate attempt to playback a recorded example can lead to glitchy behavior since there is no sanity check of the actual data sitting in QSPI. If one were to make sure to record a sample before playback, behavior would not show up. So this is just a simple safe guard.
