### PR TITLE
program change now also works with uart-midi (not only midisub)

### DIFF
--- a/Adafruit_NeoTrellisM4.cpp
+++ b/Adafruit_NeoTrellisM4.cpp
@@ -267,13 +267,19 @@ void Adafruit_NeoTrellisM4::controlChange(byte control, byte value) {
 /**************************************************************************/
 /*!
     @brief  Send program change MIDI message
-    @param    channel Ranges from 0-15
     @param    program 7-bit program value
 */
 /**************************************************************************/
-void Adafruit_NeoTrellisM4::programChange(byte channel, byte program) {
-  midiEventPacket_t pc = {0x0C, 0xC0 | channel, program, 0};
-  MidiUSB.sendMIDI(pc);
+void Adafruit_NeoTrellisM4::programChange(byte program) {
+  if (_midi_usb) {
+    midiEventPacket_t pc = {0x0C, 0xC0 | _midi_channel_usb, program, 0};
+    MidiUSB.sendMIDI(pc);
+    _pending_midi = true;
+  }
+  if (_midi_uart) {
+    Serial1.write(0xC0 | _midi_channel_uart);
+    Serial1.write(program);
+  }
 }
 
 /**************************************************************************/

--- a/Adafruit_NeoTrellisM4.h
+++ b/Adafruit_NeoTrellisM4.h
@@ -42,7 +42,7 @@ public:
   void pitchBend(int value);
   void controlChange(byte control, byte value);
   void sendMIDI(void);
-  void programChange(byte channel, byte program);
+  void programChange(byte program);
 
 private:
   int _num_keys, _rows, _cols;


### PR DESCRIPTION
* program change works with uart
* removed the channel parameter from the programChange-method

only changed the header Adafruit_NeoTrellisM4.h for the removal of the channel-parameter and the programChange-method in Adafruit_NeoTrellisM4.cpp 